### PR TITLE
Correction for errata in dictionary functions

### DIFF
--- a/Digital World Python Cheat Sheet/10.009 Digital World Cheat Sheet.md
+++ b/Digital World Python Cheat Sheet/10.009 Digital World Cheat Sheet.md
@@ -158,8 +158,11 @@ It is not advisable to declare using the the syntax `ls = [[0]*3]` as it makes t
 m_dict = {} # Creates an empty dict
 f_dict = {'name':'John Doe', 'occupation':'student', 'energy_level': 0}
 
-# Get list of items
-f_dict.items() # Returns ['name', 'occupation', 'energy_level']
+# Get list of item pairs
+f_dict.items() # Returns [('name', 'John Doe'), ('occupation', 'student'), ('energy_level, 0)]
+
+# Get list of keys
+f_dict.keys() # Returns ['name', 'occupation', 'energy_level
 
 # Get list of values
 f_dict.values() # Returns ['John Doe', 'student', 0]


### PR DESCRIPTION
dict.items() returns a list of key-value pairs instead of just a list of keys.